### PR TITLE
[name][xs]: fixed resources name in order to qualify for specifications

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -13,7 +13,7 @@
   ],
   "resources": [
     {
-      "name": "sequencing costs",
+      "name": "sequencing-costs",
       "path": "data/sequencing_costs.csv",
       "format": "csv",
       "mediatype": "text/csv",
@@ -22,6 +22,7 @@
           {
             "name": "Date",
             "type": "date",
+            "format": "any",
             "description": "Date format YYYY-MM"
           },
           {


### PR DESCRIPTION
* Fixed resources name according to the following specification:
https://pre-v1.frictionlessdata.io/data-packages/#required-fields
* Replaced date "format" to "any" since we have a date column which is not valid for ISO8601 format string. See the following specification about date formats:
https://pre-v1.frictionlessdata.io/json-table-schema/#date